### PR TITLE
Use mimalloc and huge pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,18 @@ find_package(absl)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JEMALLOC jemalloc)
+pkg_check_modules(MIMALLOC mimalloc)
 
 
-if(JEMALLOC_FOUND)
+if(MIMALLOC_FOUND)
+    add_definitions(-DUSE_MIMALLOC)
+    include_directories(${MIMALLOC_INCLUDE_DIRS})
+    set(optionalLibs ${optionalLibs} ${MIMALLOC_LIBRARIES})
+    message(STATUS "Use mimalloc as the default allocator: ${MIMALLOC_INCLUDE_DIRS} and ${MIMALLOC_LIBRARIES}.")
+elseif(JEMALLOC_FOUND)
     set(optionalLibs ${optionalLibs} ${JEMALLOC_LIBRARIES})
     message(STATUS "Use jemalloc as the default allocator.")
-endif(JEMALLOC_FOUND)
+endif()
 
 if(absl_FOUND)
     add_definitions(-DUSE_ABSL_HASHMAP)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,11 @@ RUN savedAptMark="$(apt-mark showmanual)" \
     && cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=${SEG_HOME}/abseil -DABSL_BUILD_TESTING=OFF -DABSL_PROPAGATE_CXX_STD=ON -DCMAKE_BUILD_TYPE=Release \
     && cmake --build . --target install -v \
     && cd ${SEG_HOME} && rm -rf abseil-cpp \
+    && git clone --depth 1 --branch v2.0.9 https://github.com/microsoft/mimalloc.git \
+    && cd mimalloc && mkdir build && cd build \
+    && cmake .. -G Ninja -DMI_INSTALL_TOPLEVEL=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build . --target install -v \
+    && cd ${SEG_HOME} && rm -rf mimalloc \
     && echo "[GoogleCompute]\nservice_account = default" > /etc/boto.cfg \
     && mkdir -p ${SEG_HOME}/build \
     && cd ${SEG_HOME}/build \

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -113,3 +113,5 @@ try source $SECRETS/config.sh
 export SEG_MIP=0
 export WS_MIP=0
 export FILE_PATH=$SCRATCH_PATH/$STAGE
+
+export MIMALLOC_VERBOSE=1

--- a/src/agg/mean_aggl.cpp
+++ b/src/agg/mean_aggl.cpp
@@ -491,6 +491,15 @@ inline agglomeration_data_t<T, Compare> preprocess_inputs(const char * rg_filena
     auto & seg_indices = agg_data.seg_indices;
     auto & rg_vector = agg_data.rg_vector;
 
+#ifdef USE_MIMALLOC
+    auto rg_size = filesize(rg_filename);
+    size_t huge_pages = rg_size * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     rg_vector = read_array<edge_t<T> >(rg_filename);
 
     std::vector<std::pair<seg_t, size_t> > ns_pair_array = read_array<std::pair<seg_t, size_t> >(ns_filename);

--- a/src/global_types.h
+++ b/src/global_types.h
@@ -1,5 +1,9 @@
 #ifndef GLOBAL_TYPES_H
 #define GLOBAL_TYPES_H
+#ifdef USE_MIMALLOC
+#include <mimalloc.h>
+#include <mimalloc-new-delete.h>
+#endif
 
 #ifdef USE_ABSL_HASHMAP
 #include <absl/container/flat_hash_set.h>

--- a/src/seg/atomic_chunk_ME.cpp
+++ b/src/seg/atomic_chunk_ME.cpp
@@ -37,6 +37,14 @@ int main(int argc, char * argv[])
     std::cout << dim[0] << " " << dim[1] << " " << dim[2] << std::endl;
     std::string chunk_tag(argv[2]);
 
+#ifdef USE_MIMALLOC
+    size_t huge_pages = dim[0] * dim[1] * dim[2] * 4 * 3 * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     //FIXME: wrap these in classes
     bio::mapped_file_source seg_file;
     size_t seg_bytes = sizeof(seg_t)*dim[0]*dim[1]*dim[2];

--- a/src/seg/match_chunks.cpp
+++ b/src/seg/match_chunks.cpp
@@ -416,6 +416,16 @@ void write_extra_remaps(remap_data<T> & rep)
 
 int main(int argc, char * argv[])
 {
+
+#ifdef USE_MIMALLOC
+    auto rg_size = filesize("o_residual_rg.data");
+    size_t huge_pages = rg_size * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     std::string tag(argv[1]);
     auto rep = generate_remaps<seg_t>();
     std::cout << "remaps loaded" << std::endl;

--- a/src/seg/merge_edges_ME.cpp
+++ b/src/seg/merge_edges_ME.cpp
@@ -15,6 +15,15 @@ int main(int argc, char * argv[])
 {
     std::string tag(argv[1]);
 
+#ifdef USE_MIMALLOC
+    auto rg_size = filesize(str(boost::format("incomplete_edges_%1%.tmp") % tag));
+    size_t huge_pages = rg_size * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     SetContainer<seg_t> incomplete_segments;
     for (size_t i = 0; i != 6; i++) {
         incomplete_segments.merge(updateBoundarySegments<seg_t>(i, tag));

--- a/src/seg/reduce_chunk.cpp
+++ b/src/seg/reduce_chunk.cpp
@@ -206,6 +206,16 @@ void reduce_size(const std::string & tag, const MapContainer<T, T> & remaps)
 int main(int argc, char ** argv)
 {
     std::string tag(argv[1]);
+
+#ifdef USE_MIMALLOC
+    auto rg_size = filesize(str(boost::format("residual_rg_%1%.data") % tag));
+    size_t huge_pages = rg_size * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     auto remap_array = read_array<remap_data_t<seg_t> >("remap.data");
     auto remaps = consolidate_remap(remap_array);
     auto ongoing_size_array = read_array<size_data_t<seg_t> >("ongoing_segments.data");

--- a/src/ws/atomic_chunk.cpp
+++ b/src/ws/atomic_chunk.cpp
@@ -63,6 +63,15 @@ int main(int argc, char* argv[])
     std::string lt(argv[4]);
     std::string st(argv[5]);
     std::cout << "thresholds: "<< ht << " " << lt << " " << st << std::endl;
+
+#ifdef USE_MIMALLOC
+    size_t huge_pages = xdim * ydim * zdim * 4 * 3 * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     const char * tag = argv[6];
     auto high_threshold = read_float<aff_t>(ht);
     auto low_threshold = read_float<aff_t>(lt);

--- a/src/ws/merge_chunks.cpp
+++ b/src/ws/merge_chunks.cpp
@@ -689,6 +689,14 @@ int main(int argc, char* argv[])
     }
     param_file >> face_size >> counts >> dend_size >> remap_size >> ac_offset;
 
+#ifdef USE_MIMALLOC
+    size_t huge_pages = (face_size + dend_size + counts) * (8 + 8 + 8) * 4 / 1024 / 1024 / 1024 + 1;
+    auto mi_ret = mi_reserve_huge_os_pages_interleave(huge_pages, 0, 0);
+    if (mi_ret == ENOMEM) {
+       std::cout << "failed to reserve 1GB huge pages" << std::endl;
+    }
+#endif
+
     if (face_size == 0) {
         std::cout << "Nothing to merge, exit!" << std::endl;
         SlicedOutput<std::pair<seg_t, seg_t>, seg_t> remap_output(str(boost::format("done_pre_%1%.data") % tag));


### PR DESCRIPTION
When the reserved huge pages are large enough to contain all the data, the code runs ~2x faster (comparing to jemalloc shipped with ubuntu 20.04). The allocator fallbacks to normal 4K pages if it cannot reserve huge pages. Mimalloc seems to use more memory than jemalloc, but still need to test whether the overhead is a significant problem.